### PR TITLE
Use newest version of duo_universal_java library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.duosecurity.plugin</groupId>
     <artifactId>duo-universal-oam</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 
     <build>
         <finalName>${project.artifactId}</finalName>
@@ -20,8 +20,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.duosecurity</groupId>
             <artifactId>duo-universal-sdk</artifactId>
-            <version>1.0.3</version>
+            <version>1.3.1</version>
         </dependency>
 
         <!-- These dependencies are provided at runtime, however maven

--- a/src/main/java/com/duosecurity/plugin/DuoUniversalPlugin.java
+++ b/src/main/java/com/duosecurity/plugin/DuoUniversalPlugin.java
@@ -89,8 +89,9 @@ public class DuoUniversalPlugin extends AbstractAuthenticationPlugIn {
                 LOGGER.log(Level.CONFIG, "Duo Plugin is using default User Store");
             }
 
-            this.duoClient = new Client(this.client_id, this.client_secret, this.host, this.redirectUrl);
-            this.duoClient.appendUserAgentInfo(getUserAgent());
+            this.duoClient = new Client.Builder(this.client_id, this.client_secret, this.host, this.redirectUrl)
+                                       .appendUserAgentInfo(getUserAgent())
+                                       .build();
         } catch (Exception error) {
             LOGGER.log(Level.SEVERE,
                        "Error initializing Duo plugin",


### PR DESCRIPTION
## Description
Update the version of the duo universal sdk to the latest (1.3.1).  Adapt the client to use the Builder.  Update the java target since 6 is no longer supported by maven.

## Motivation and Context
To incoporate the CA pinning bundle updates in the universal SDK.

## How Has This Been Tested?
Tested the build process; will need to manually test the plugin.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
