### PR TITLE
Add option to disable CA certificate pinning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.duosecurity</groupId>
             <artifactId>duo-universal-sdk</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.2</version>
         </dependency>
 
         <!-- These dependencies are provided at runtime, however maven

--- a/src/main/java/com/duosecurity/plugin/DuoUniversalPlugin.java
+++ b/src/main/java/com/duosecurity/plugin/DuoUniversalPlugin.java
@@ -45,6 +45,7 @@ public class DuoUniversalPlugin extends AbstractAuthenticationPlugIn {
     private static final String REDIRECT_PARAM = "Redirect URL";
     private static final String STORE_PARAM = "User Store";
     private static final String FAILMODE = "Fail mode";
+    private static final String DISABLE_CA_PINNING_PARAM = "Disable CA Pinning";
     private static final String SESSION_STATE = "duoState";
     private static final String CREDENTIAL_NAME_CODE = "duo_code";
     private static final String CREDENTIAL_NAME_STATE = "state";
@@ -59,6 +60,7 @@ public class DuoUniversalPlugin extends AbstractAuthenticationPlugIn {
     String host = null;
     String redirectUrl = null;
     Failmode failmode = Failmode.CLOSED;
+    boolean disableCaPinning = false;
     String userStore = null;
 
     Client duoClient;
@@ -81,6 +83,7 @@ public class DuoUniversalPlugin extends AbstractAuthenticationPlugIn {
             }
 
             this.failmode = determineFailmode(config.getParameter(FAILMODE));
+            this.disableCaPinning = determineCaPinningDisabled(config.getParameter(DISABLE_CA_PINNING_PARAM));
             String configuredStore = (String) config.getParameter(STORE_PARAM);
             if (configuredStore != null && !configuredStore.equals("")) {
                 LOGGER.log(Level.CONFIG, "Duo Plugin is using custom User Store " + configuredStore);
@@ -89,9 +92,13 @@ public class DuoUniversalPlugin extends AbstractAuthenticationPlugIn {
                 LOGGER.log(Level.CONFIG, "Duo Plugin is using default User Store");
             }
 
-            this.duoClient = new Client.Builder(this.client_id, this.client_secret, this.host, this.redirectUrl)
-                                       .appendUserAgentInfo(getUserAgent())
-                                       .build();
+            Client.Builder clientBuilder = new Client.Builder(this.client_id, this.client_secret, this.host, this.redirectUrl)
+                                       .appendUserAgentInfo(getUserAgent());
+            if (this.disableCaPinning) {
+                clientBuilder.disableCaPinning();
+                LOGGER.log(Level.WARNING, "CA pinning is disabled. TLS connections will validate against the default trust store.");
+            }
+            this.duoClient = clientBuilder.build();
         } catch (Exception error) {
             LOGGER.log(Level.SEVERE,
                        "Error initializing Duo plugin",
@@ -102,6 +109,18 @@ public class DuoUniversalPlugin extends AbstractAuthenticationPlugIn {
         LOGGER.log(Level.CONFIG, "Duo Plugin fail mode is set to fail " + (this.failmode == Failmode.CLOSED ? "closed" : "open"));
 
         return ExecutionStatus.SUCCESS;
+    }
+
+    static boolean determineCaPinningDisabled(Object configParam) {
+        if (configParam == null) {
+            return false;
+        }
+
+        if (!(configParam instanceof String)) {
+            return false;
+        }
+
+        return "true".equalsIgnoreCase((String) configParam);
     }
 
     static Failmode determineFailmode(Object configParam) {

--- a/src/main/resources/DuoUniversalPlugin.xml
+++ b/src/main/resources/DuoUniversalPlugin.xml
@@ -46,5 +46,12 @@
         <globalUIOverride>true</globalUIOverride>
         <value></value>
     </AttributeValuePair>
+    <AttributeValuePair>
+        <Attribute type="string" length="5">Disable CA Pinning</Attribute>
+        <mandatory>false</mandatory>
+        <instanceOverride>false</instanceOverride>
+        <globalUIOverride>true</globalUIOverride>
+        <value></value>
+    </AttributeValuePair>
   </configuration>
 </Plugin>

--- a/src/test/java/com/duosecurity/plugin/DuoUniversalPluginConfigTest.java
+++ b/src/test/java/com/duosecurity/plugin/DuoUniversalPluginConfigTest.java
@@ -64,5 +64,35 @@ public class DuoUniversalPluginConfigTest {
         assertTrue(ua.toLowerCase().contains("os.arch"));
         assertTrue(ua.toLowerCase().contains("os.version"));
     }
+
+    @Test
+    public void testDetermineCaPinningDisabledNull() {
+        assertFalse(DuoUniversalPlugin.determineCaPinningDisabled(null));
+    }
+
+    @Test
+    public void testDetermineCaPinningDisabledNonString() {
+        assertFalse(DuoUniversalPlugin.determineCaPinningDisabled(Integer.valueOf(1)));
+    }
+
+    @Test
+    public void testDetermineCaPinningDisabledFalse() {
+        assertFalse(DuoUniversalPlugin.determineCaPinningDisabled("false"));
+    }
+
+    @Test
+    public void testDetermineCaPinningDisabledNonsense() {
+        assertFalse(DuoUniversalPlugin.determineCaPinningDisabled("not a boolean"));
+    }
+
+    @Test
+    public void testDetermineCaPinningDisabledTrue() {
+        assertTrue(DuoUniversalPlugin.determineCaPinningDisabled("true"));
+    }
+
+    @Test
+    public void testDetermineCaPinningDisabledTrueMixedCase() {
+        assertTrue(DuoUniversalPlugin.determineCaPinningDisabled("True"));
+    }
 }
 


### PR DESCRIPTION
## Summary

- Adds `"Disable CA Pinning"` plugin configuration parameter that disables the bundled CA certificate pin set while keeping TLS verification active via the default trust store
- Bumps `duo-universal-sdk` from 1.3.1 to 1.3.2 (includes `disableCaPinning()` on `Client.Builder`)
- Logs a warning at startup when pinning is disabled

## Test plan

- [x] Unit tests verify config parsing handles null, non-String, "false", and nonsense input correctly
- [x] Unit tests verify "true" and "True" enable the setting
- [x] Full test suite passes (37 tests)