### PR TITLE
chore: update GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,15 +18,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -15,7 +15,8 @@ jobs:
        - name: Set up Java
          uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
          with:
-           java-version: 1.8
+           distribution: temurin
+           java-version: 8
 
        - name: Build and test with Maven
          run: mvn -B install

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -11,9 +11,9 @@ jobs:
    build-and-test:
      runs-on: ubuntu-latest
      steps:
-       - uses: actions/checkout@v3
+       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
        - name: Set up Java
-         uses: actions/setup-java@v1
+         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
          with:
            java-version: 1.8
 

--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -10,9 +10,9 @@ jobs:
    build-and-test:
      runs-on: ubuntu-latest
      steps:
-       - uses: actions/checkout@v3
+       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
        - name: Set up Java
-         uses: actions/setup-java@v1
+         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
          with:
            java-version: 1.8
 

--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -14,7 +14,8 @@ jobs:
        - name: Set up Java
          uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
          with:
-           java-version: 1.8
+           distribution: temurin
+           java-version: 8
 
        - name: Build and test with Maven
          run: mvn clean package


### PR DESCRIPTION
## Summary
Updates GitHub Actions to Node 24-compatible versions ahead of the runner change: GitHub Actions runners default to Node 24 on **2026-06-16** and remove Node 20 in **fall 2026**. JS actions on Node 12/16/20 are all affected.

Every JS-based action is bumped to its latest Node 24-capable release, **SHA-pinned** with a version comment.

## Not changed (no Node 24 release / composite / archived)
- `darenm/Setup-VSTest` — no Node 24 release exists
- `dtolnay/rust-toolchain` — composite action, unaffected
- `actions/create-release`, `actions/upload-release-asset` — archived; need a rewrite

Only present where applicable in this repo.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

*This PR was generated with AI assistance (Claude).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)