### PR TITLE
Add CA bundle version and pinning status to the user agent string

### DIFF
--- a/src/main/java/com/duosecurity/plugin/DuoUniversalPlugin.java
+++ b/src/main/java/com/duosecurity/plugin/DuoUniversalPlugin.java
@@ -39,6 +39,7 @@ import com.duosecurity.model.Token;
 public class DuoUniversalPlugin extends AbstractAuthenticationPlugIn {
 
     private static final String JAR_VERSION = "2.1.0";
+    private static final String CA_BUNDLE_VERSION = "1.0";
     private static final String CLIENT_ID_PARAM = "Client ID";
     private static final String CLIENT_SECRET_PARAM = "Client Secret";
     private static final String HOST_PARAM = "API hostname";
@@ -93,7 +94,7 @@ public class DuoUniversalPlugin extends AbstractAuthenticationPlugIn {
             }
 
             Client.Builder clientBuilder = new Client.Builder(this.client_id, this.client_secret, this.host, this.redirectUrl)
-                                       .appendUserAgentInfo(getUserAgent());
+                                       .appendUserAgentInfo(getUserAgent(this.disableCaPinning));
             if (this.disableCaPinning) {
                 clientBuilder.disableCaPinning();
                 LOGGER.log(Level.WARNING, "CA pinning is disabled. TLS connections will validate against the default trust store.");
@@ -470,7 +471,7 @@ public class DuoUniversalPlugin extends AbstractAuthenticationPlugIn {
         }
     }
 
-    static String getUserAgent() {
+    static String getUserAgent(boolean caPinningDisabled) {
         String userAgent = "duo_universal_oam/jar " + JAR_VERSION  + " (";
 
         userAgent = addKeyValueToUserAgent(userAgent, "java.version") + "; ";
@@ -479,6 +480,9 @@ public class DuoUniversalPlugin extends AbstractAuthenticationPlugIn {
         userAgent = addKeyValueToUserAgent(userAgent, "os.version");
 
         userAgent += ")";
+
+        userAgent += " ca_bundle/" + CA_BUNDLE_VERSION
+                     + " (ca_pinning=" + (caPinningDisabled ? "disabled" : "enabled") + ")";
 
         return userAgent;
     }

--- a/src/test/java/com/duosecurity/plugin/DuoUniversalPluginConfigTest.java
+++ b/src/test/java/com/duosecurity/plugin/DuoUniversalPluginConfigTest.java
@@ -56,13 +56,39 @@ public class DuoUniversalPluginConfigTest {
 
     @Test
     public void testGetUserAgent() {
-        String ua = duoUniversalPlugin.getUserAgent();
+        String ua = duoUniversalPlugin.getUserAgent(false);
         assertNotNull(ua);
         assertTrue(ua.toLowerCase().contains("duo_universal_oam/"));
         assertTrue(ua.toLowerCase().contains("java.version"));
         assertTrue(ua.toLowerCase().contains("os.name"));
         assertTrue(ua.toLowerCase().contains("os.arch"));
         assertTrue(ua.toLowerCase().contains("os.version"));
+    }
+
+    @Test
+    public void testGetUserAgentIncludesCaBundleVersion() {
+        assertTrue(duoUniversalPlugin.getUserAgent(false).contains("ca_bundle/1.0"));
+        assertTrue(duoUniversalPlugin.getUserAgent(true).contains("ca_bundle/1.0"));
+    }
+
+    @Test
+    public void testGetUserAgentCaPinningEnabled() {
+        String ua = duoUniversalPlugin.getUserAgent(false);
+        assertTrue(ua.contains("(ca_pinning=enabled)"));
+        assertFalse(ua.contains("(ca_pinning=disabled)"));
+    }
+
+    @Test
+    public void testGetUserAgentCaPinningDisabled() {
+        String ua = duoUniversalPlugin.getUserAgent(true);
+        assertTrue(ua.contains("(ca_pinning=disabled)"));
+        assertFalse(ua.contains("(ca_pinning=enabled)"));
+    }
+
+    @Test
+    public void testGetUserAgentFieldOrder() {
+        String ua = duoUniversalPlugin.getUserAgent(false);
+        assertTrue(ua.endsWith(" ca_bundle/1.0 (ca_pinning=enabled)"));
     }
 
     @Test


### PR DESCRIPTION
## Description
  - Added `CA_BUNDLE_VERSION = "1.0"` constant in `DuoUniversalPlugin.java`
  - Changed `getUserAgent()` to take the pinning state and append `ca_bundle/1.0` and `(ca_pinning=enabled|disabled)` to the user agent string
  - The pinning status is derived from the same `disableCaPinning` flag passed to `Client.Builder.disableCaPinning()`, so the reported value always matches the client's actual pinning state

## How Has This Been Tested?
  - `testGetUserAgentIncludesCaBundleVersion` — verifies `ca_bundle/1.0` is present in both pinning states
  - `testGetUserAgentCaPinningEnabled` — verifies `(ca_pinning=enabled)` when pinning is not disabled
  - `testGetUserAgentCaPinningDisabled` — verifies `(ca_pinning=disabled)` when pinning is disabled
  - `testGetUserAgentFieldOrder` — asserts the string ends with the expected `ca_bundle/1.0 (ca_pinning=enabled)` suffix
  - `testGetUserAgent` — updated for the new method signature
  - Full suite passes: 41 tests, 0 failures

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
